### PR TITLE
feat: introduce RoundedMaterialButtonStyle

### DIFF
--- a/QRiosity.xcodeproj/project.pbxproj
+++ b/QRiosity.xcodeproj/project.pbxproj
@@ -154,6 +154,14 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
+		5E5C47FA2778ABBC00AFE71A /* Buttons */ = {
+			isa = PBXGroup;
+			children = (
+				5E5C47FB2778B0E500AFE71A /* RoundedMaterialButtonStyle.swift */,
+			);
+			path = Buttons;
+			sourceTree = "<group>";
+		};
 		5E5D23B024FEA95B00124551 = {
 			isa = PBXGroup;
 			children = (
@@ -223,6 +231,7 @@
 		5EC711472708426800838BC2 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				5E5C47FA2778ABBC00AFE71A /* Buttons */,
 				5EC711482708427C00838BC2 /* SafariView.swift */,
 			);
 			path = Views;
@@ -453,6 +462,7 @@
 				5E582E16250926D100D9F203 /* HistoryView.swift in Sources */,
 				5E582E13250926B600D9F203 /* CollectedList.swift in Sources */,
 				5ECE0CB024FFE7BF0084C73B /* CodeRecord+CoreDataClass.swift in Sources */,
+				5E5C47FC2778B0E500AFE71A /* RoundedMaterialButtonStyle.swift in Sources */,
 				5E5D23BF24FEA95B00124551 /* ContentView.swift in Sources */,
 				5EC711512708561D00838BC2 /* NSManagedObjectContext.swift in Sources */,
 				5EC711572708B37B00838BC2 /* OpenGraph+.swift in Sources */,

--- a/Shared/Views/Buttons/RoundedMaterialButtonStyle.swift
+++ b/Shared/Views/Buttons/RoundedMaterialButtonStyle.swift
@@ -1,0 +1,41 @@
+//
+//  RoundedMaterialButtonStyle.swift
+//  QRiosity
+//
+//  Created by mrfour on 2021/12/26.
+//  Copyright © 2021 mrfour. All rights reserved.
+//
+
+import SwiftUI
+
+/// A button style that applies a large corner radius and material background based on the button's context.
+///
+/// - Note: This is currently the main style for buttons whose `label` is an icon. May have a more mature design system
+/// and have a better name in the next phase.
+struct RoundedMaterialButtonStyle: ButtonStyle {
+    enum Design {
+        static let shape = RoundedRectangle(cornerRadius: 24, style: .continuous)
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(width: 24, height: 24)
+            // TODO: will have a better color for destructive later
+            .foregroundColor(configuration.role == .destructive ? .red : .secondary)
+            .padding()
+            .background(.ultraThickMaterial, in: Design.shape)
+            .scaleEffect(configuration.isPressed ? 0.85 : 1)
+            .background(.ultraThinMaterial, in: Design.shape)
+            .scaleEffect(configuration.isPressed ? 1.1 : 1)
+            .animation(.spring(response: 0.4), value: configuration.isPressed)
+    }
+}
+
+extension ButtonStyle where Self == RoundedMaterialButtonStyle {
+    /// A button style that applies a large corner radius and material background based on the button's context.
+    ///
+    /// To apply this style to a button, or to a view that contains buttons, use the `buttonStyle(_:)` modifier.
+    static var roundedMaterial: RoundedMaterialButtonStyle {
+        RoundedMaterialButtonStyle()
+    }
+}


### PR DESCRIPTION
Introduce the first (draft) version of `RoundedMaterialButtonStyle`. 

The detail configuration, e.g. color, size, and etc., might be tweaked in the future.